### PR TITLE
Fix sequential file read/write. Relative files and direct access not supported.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ VPATH = src
 ALL_LIBS = c64.a
 
 # Common source files
-ASM_SRCS = c64startup.s stub_exit.s stub_putchar.s stub_read.s
-C_SRCS = stub_lseek.c stub_write.c stub_close.c
+ASM_SRCS = commodore-startup.s stub_exit.s stub_read.s kernal.s
+C_SRCS = stub_lseek.c stub_write.c stub_close.c stub_open.c
 
 # Object files
 OBJS = $(ASM_SRCS:%.s=%.o) $(C_SRCS:%.c=%.o)

--- a/src/stub_open.c
+++ b/src/stub_open.c
@@ -37,13 +37,16 @@ int _Stub_open(const char *path, int oflag, ...) {
     // Allocate a file descriptor
     uint8_t fd = 3;
     uint8_t r = 1;
-    while ((__fd_resources & r)) {
+    while ((__fd_resources & r) && (fd < 15)) {
       fd++;
       r <<= 1;
     }
+    if (fd == 15) {
+      return EOF;
+    }
 
     __fd_resources |= r;
-    __set_logical_file(fd, device, 255);
+    __set_logical_file(fd, device, fd);
     __set_filename(path, strlen(path));
     if (__kernel_call_failed(__open())) {
       return EOF;

--- a/src/stub_read.s
+++ b/src/stub_read.s
@@ -3,13 +3,14 @@
 CHKIN:	      .equlab 0xffc6
 CHRIN:	      .equlab 0xffcf
 READST:	      .equlab 0xffb7
+CLRCHN:       .equlab 0xffcc
 
               .section code
               .public _Stub_read
 _Stub_read:   ldx     zp:_Zp+0
 	      beq     start$	    ; stdin
 	      cpx     #3	    ; test for stdout/stderr
-	      bcs     eof$
+	      bcc     eof$
 	      jsr     CHKIN	    ; ensure channel is prepared to read
 start$:	      lda     #0	    ; set file counter = 0
               sta     zp:_Zp+0
@@ -35,7 +36,10 @@ start$:	      lda     #0	    ; set file counter = 0
               iny
               bne     25$
 30$:	      jsr     READST	    ; check for error
-	      tax
+	      tay
+          jsr     CLRCHN
+          tya
+          tax 
 	      beq     done$
 eof$:	      lda     #-1
 	      sta     zp:_Zp+0

--- a/src/stub_write.c
+++ b/src/stub_write.c
@@ -5,6 +5,7 @@
 #include "lib.h"
 
 #define CHROUT(c) ( (void (*)(char) ) 0xffd2) (c)
+#define CLRCHN() ( (void (*)() ) 0xffcc)()
 
 size_t _Stub_write (int fd, const void *buf, size_t count) {
   const char *p = buf;
@@ -15,7 +16,6 @@ size_t _Stub_write (int fd, const void *buf, size_t count) {
     if (((1 << (fd - 3)) & __fd_resources) == 0) {
       goto bad;
     }
-    return count;
     // prepare for output
     if (__kernel_call_failed(__chkout(fd))) {
       return EOF;
@@ -38,8 +38,10 @@ size_t _Stub_write (int fd, const void *buf, size_t count) {
       return (size_t) -1;
   }
   if (__read_status()) {
+    CLRCHN();
     return EOF;
   } else {
+    CLRCHN();
     return n;
   }
 }


### PR DESCRIPTION
Limit the open to use file numbers no greater than 14
Set the secondary address to equal the file number (thus having a range from 3-14).
Flip the bcs to a bcc, to error out on trying to read file numbers < 3 instead of >=3
Remove the early-out success report when writing to files
Call CLRCHN after completing a read or write block, so that following printf/scanf/gets does not go to the disk drive. Not 100% sure if this is needed, but it keeps the stub_read and stub_write functions cleaning up after themselves.

Tested with the following test program:

int main () {
  printf("HELLO, WORLD! This is a new day.\r\n");

  printf("OPENING FILE!\r");
  FILE *pcxfile = fopen("COUGAR2.PCX,P,R", "rb");
  if (pcxfile == NULL) {
    printf("FAILED OPENING FILE!\r\n");
  }

  fread(pcxheader, 1, 128, pcxfile);

  for (uint8_t i = 0; i < 8; i++) {
    printf("%01x0:", i);
    for (uint8_t j = 0; j < 16; j++) {
      printf(" %02x", pcxheader[(i << 4) | j]);
    }
    printf("\r");
  }

  if (pcxheader[0] != 0x0a) {
    printf("NOT A PCX FILE!\r\n");
  }
  fclose(pcxfile);

  FILE *datafile = fopen("TESTDATA,S,W", "wb");
  if (datafile == NULL) {
    printf("FAILED TO WRITE DATAFILE!");
  }
  fprintf(datafile, "THIS IS SOME TEST DATA!\r\n");
  printf("THIS IS NOT IN THE DATA FILE!\r\n");
  fclose(datafile);
  printf("TEST COMPLETE.\r\n");
}